### PR TITLE
Allocate fresh mbuf when receiving small packets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "drivex"]
 	path = drivex
-	url = ssh://l-gerrit.mtl.labs.mlnx:29418/drivex
+	url = https://github.com/Mellanox/freebsd_drivex_generated.git
 	branch = master

--- a/README
+++ b/README
@@ -1,0 +1,11 @@
+READONLY clone of drivers to be used with Connectx-3 and Connectx-4.
+
+The top commit in this repository includes changes needed for the code to be used outside of Mellanox.
+The repository should be synced automiaticlly with the internal copy at Mellanox.
+
+In order to compile the driver, you will need:
+
+- 11-current.
+- compiling and loading the linuxapi module. (mlx5/mlx5en only)
+
+For any problem please contact freebsd-drivers@mellanox.com.

--- a/drivers/net/mlx5/en.h
+++ b/drivers/net/mlx5/en.h
@@ -392,6 +392,7 @@ struct mlx5e_cq {
 
 struct mlx5e_rq_mbuf {
 	bus_dmamap_t dma_map;
+	caddr_t data;
 	struct mbuf *mbuf;
 };
 

--- a/mlx5_build.sh
+++ b/mlx5_build.sh
@@ -5,7 +5,6 @@ SRC="$1"
 [ -z "$SRC" ] && SRC="/usr/src"
 
 echo "The FreeBSD source tree is at $SRC ..."
-bmake -m $SRC/share/mk SYSDIR=$SRC/sys -C mlx5_modules $LRO generate
 bmake -m $SRC/share/mk SYSDIR=$SRC/sys -C mlx5_modules $LRO clean cleandepend
 bmake -m $SRC/share/mk SYSDIR=$SRC/sys -C mlx5_modules $LRO depend
 bmake -m $SRC/share/mk SYSDIR=$SRC/sys -C mlx5_modules $LRO all -j12

--- a/mlx5_modules/Makefile
+++ b/mlx5_modules/Makefile
@@ -2,5 +2,3 @@ SUBDIR=mlx5 mlx5en # mlx5ib
 
 .include <bsd.subdir.mk>
 
-generate:
-	cd ../drivex/mlx5 && python generate_files.py -t freebsd


### PR DESCRIPTION
If the incoming packet can fit inside a single mbuf (without needing a cluster)

- Allocate fresh mbuf.
- Copy data to that mbuf.
- Leave the cluster mapped (Won't unload the dmamap).
- Pass fresh mbuf up the stack.

Signed-off-by: Mark Bloch <markb@mellanox.com>